### PR TITLE
Use re_flags to remove dependency on version number for finding vers

### DIFF
--- a/WiresharkDev/WiresharkDev.download.recipe
+++ b/WiresharkDev/WiresharkDev.download.recipe
@@ -28,7 +28,12 @@
                     <string>Safari 8.0.2</string>
                 </dict>
                 <key>re_pattern</key>
-                <string>Wireshark 1\.[2-9][1-9]\.[1-9] Intel 64\.dmg</string>
+                <string>Development Release.*(Wireshark 1\.[1-9][1-9]\.[1-9] Intel 64\.dmg)</string>
+                <key>re_flags</key>
+                <array>
+                    <string>MULTILINE</string>
+                    <string>DOTALL</string>
+                </array>
                 <key>result_output_var_name</key>
                 <string>match</string>
             </dict>


### PR DESCRIPTION
I had this recipe all written up only to discover that you had already done so. Rather than have no 3 Wireshark recipes in the AutoPkg org I figured I'd just send you the one thing that makes it different:

Instead of making the pattern match by changing the numbers accepted in the minor version part of the regex, I used the `re.MULTILINE` and `re.DOTALL` flags and changed the regex to first look for the Development Releases section, and THEN find the first mac 64 download (using a regex group).

Works great, and should be (slighltly) more future proof if they keep developing the prod and devel versions in tandem, but bump the prod minor version number.