### PR TITLE
Added postinstall_script to VMWare munki recipes

### DIFF
--- a/VMware Fusion/VMwareFusion.munki.recipe
+++ b/VMware Fusion/VMwareFusion.munki.recipe
@@ -28,6 +28,13 @@
 			<array>
 				<string>testing</string>
 			</array>
+                        <key>postinstall_script</key>
+                        <string>#!/bin/bash
+if [ -e /Applications/VMware\ Fusion.app/Contents/Library/Initialize\ VMware\ Fusion.tool ]
+then
+        /Applications/VMware\ Fusion.app/Contents/Library/Initialize\ VMware\ Fusion.tool set
+fi
+                        </string>
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>

--- a/VMware Fusion/VMwareFusion.pkg.munki.recipe
+++ b/VMware Fusion/VMwareFusion.pkg.munki.recipe
@@ -33,9 +33,6 @@
 if [ -e /Applications/VMware\ Fusion.app/Contents/Library/Initialize\ VMware\ Fusion.tool ]
 then
         /Applications/VMware\ Fusion.app/Contents/Library/Initialize\ VMware\ Fusion.tool set
-else
-        echo "Initializaion tool not present"
-        exit 1
 fi
                         </string>
 		</dict>

--- a/VMware Fusion/VMwareFusion.pkg.munki.recipe
+++ b/VMware Fusion/VMwareFusion.pkg.munki.recipe
@@ -28,6 +28,16 @@
 			<array>
 				<string>testing</string>
 			</array>
+                        <key>postinstall_script</key>
+                        <string>#!/bin/bash
+if [ -e /Applications/VMware\ Fusion.app/Contents/Library/Initialize\ VMware\ Fusion.tool ]
+then
+        /Applications/VMware\ Fusion.app/Contents/Library/Initialize\ VMware\ Fusion.tool set
+else
+        echo "Initializaion tool not present"
+        exit 1
+fi
+                        </string>
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>


### PR DESCRIPTION
There is an embedded tool at /Applications/VMWare Fusion.app/Contents/Library/Initialize VMWare Fusion.tool that can be run to suppress the admin credential prompt on first launch.

There is a note in the comments of the tool code on how it can be used.  The second case is ideal for deployment via munki, especially in non-admin environments:

```
#2) Unattended, by the system administrator of an organization who mass
#    deploys the application.
#
# After the application has been copied to a new machine, the system
# administrator invokes this executable as root with the first argument set to
# "set". After that, any user of the organization who starts the application on
# this machine will not be prompted for root credentials.
```

This postinstall_script works in my recipe override but wanted to pass it on in case you wanted to add it to the parent recipe.  I'm not sure if there'd be a use case where the admin prompt would be desired.

The output of the .tool when run is:

```
    *** Creating directory /Library/Application Support/VMware...
    *** Setting permissions on /Library/Application Support/VMware...
    *** Creating directory /Library/Application Support/VMware/VMware Fusion...
    *** Setting permissions on /Library/Application Support/VMware/VMware Fusion...
    *** Creating directory /Library/Application Support/VMware/VMware Fusion/AdminWritable...
    *** Setting permissions on /Library/Application Support/VMware/VMware Fusion/AdminWritable...
    *** Creating directory /Library/Application Support/VMware/VMware Fusion/Shared...
    *** Setting permissions on /Library/Application Support/VMware/VMware Fusion/Shared...
    *** Setting file permissions...
```

-Eric
