### PR TITLE
Wireshark - update for Development release 2.X

### DIFF
--- a/WiresharkDev/WiresharkDev.download.recipe
+++ b/WiresharkDev/WiresharkDev.download.recipe
@@ -28,7 +28,7 @@
                     <string>Safari 8.0.2</string>
                 </dict>
                 <key>re_pattern</key>
-                <string>Development Release.*(Wireshark 1\.[1-9][1-9]\.[1-9] Intel 64\.dmg)</string>
+                <string>(?:Development Release \()([^)]+)</string>
                 <key>re_flags</key>
                 <array>
                     <string>MULTILINE</string>
@@ -44,9 +44,9 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>https://www.wireshark.org/download/osx/%match%</string>
+                <string>https://1.na.dl.wireshark.org/osx/Wireshark %match% Intel 64.dmg</string>
                 <key>filename</key>
-                <string>%match%</string>
+                <string>Wireshark %match% Intel 64.dmg</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
A fix to cope with the 2.X development release of Wireshark (and hopefully ongoing development versions).

Changes:
 * Alter the regular expression finding the development release of Wireshark after it went up from 1.X to 2.X - pick out the stated development version from the text rather that the download URL.
 * Update the Download URL to be as advertised on the page