### PR TITLE
Allows child recipes to override NAME.

### DIFF
--- a/SublimeText/SublimeText3.pkg.recipe
+++ b/SublimeText/SublimeText3.pkg.recipe
@@ -46,9 +46,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Sublime Text.app</string>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Sublime Text.app</string>
 			</dict>
 		</dict>
 


### PR DESCRIPTION
Allows child recipes and recipe overrides to modify the NAME without causing an error during the Copier process.