### PR TITLE
Basic python3 compatibility

### DIFF
--- a/VMware Fusion/VMwareFusionCustomProcessor-test.py
+++ b/VMware Fusion/VMwareFusionCustomProcessor-test.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
+from __future__ import print_function
 import urllib, urllib2, gzip
 
 from xml.etree import ElementTree
@@ -27,12 +29,12 @@ fusion = 'fusion.xml'
 # functions
 def core_metadata(base_url, fusion):
     request = urllib2.Request(base_url+fusion)
-    print base_url
+    print(base_url)
 
     try:
         vsus = urllib2.urlopen(request)
-    except URLError, e:
-        print e.reason
+    except URLError as e:
+        print(e.reason)
 
     data = vsus.read()
     # print data
@@ -40,7 +42,7 @@ def core_metadata(base_url, fusion):
     try:
         metaList = ElementTree.fromstring(data)
     except ExpatData:
-        print "Unable to parse XML data from string"
+        print("Unable to parse XML data from string")
 
     versions = []
     for metadata in metaList:
@@ -58,7 +60,7 @@ def core_metadata(base_url, fusion):
 
     matching = [s for s in urls if latest in s]
     core = [s for s in matching if "core" in s]
-    print core[0]
+    print(core[0])
 
     vsus.close()
 
@@ -66,8 +68,8 @@ def core_metadata(base_url, fusion):
 
     try:
         vLatest = urllib2.urlopen(request)
-    except URLError, e:
-        print e.reason
+    except URLError as e:
+        print(e.reason)
 
     buf = StringIO( vLatest.read())
     f = gzip.GzipFile(fileobj=buf)
@@ -77,10 +79,10 @@ def core_metadata(base_url, fusion):
     try:
         metadataResponse = ElementTree.fromstring(data)
     except ExpatData:
-        print "Unable to parse XML data from string"
+        print("Unable to parse XML data from string")
 
     relativePath = metadataResponse.find("bulletin/componentList/component/relativePath")
-    print core[0].replace("metadata.xml.gz", relativePath.text)
-    print base_url+core[0].replace("metadata.xml.gz", relativePath.text)
+    print(core[0].replace("metadata.xml.gz", relativePath.text))
+    print(base_url+core[0].replace("metadata.xml.gz", relativePath.text))
 
 core_metadata(base_url, fusion)

--- a/VMware Fusion/VMwareFusionCustomProcessor-test.py
+++ b/VMware Fusion/VMwareFusionCustomProcessor-test.py
@@ -17,10 +17,14 @@
 from __future__ import absolute_import, print_function
 
 import gzip
-import urllib2
 from distutils.version import LooseVersion
 from StringIO import StringIO
 from xml.etree import ElementTree
+
+try:
+    from urllib.request import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 # variables
 base_url = 'https://softwareupdate.vmware.com/cds/vmw-desktop/'
@@ -28,12 +32,11 @@ fusion = 'fusion.xml'
 
 # functions
 def core_metadata(base_url, fusion):
-    request = urllib2.Request(base_url+fusion)
     print(base_url)
 
     try:
-        vsus = urllib2.urlopen(request)
-    except URLError as e:
+        vsus = urlopen(base_url + fusion)
+    except Exception as e:
         print(e.reason)
 
     data = vsus.read()
@@ -64,11 +67,9 @@ def core_metadata(base_url, fusion):
 
     vsus.close()
 
-    request = urllib2.Request(base_url+core[0])
-
     try:
-        vLatest = urllib2.urlopen(request)
-    except URLError as e:
+        vLatest = urlopen(base_url + core[0])
+    except Exception as e:
         print(e.reason)
 
     buf = StringIO( vLatest.read())

--- a/VMware Fusion/VMwareFusionCustomProcessor-test.py
+++ b/VMware Fusion/VMwareFusionCustomProcessor-test.py
@@ -23,8 +23,10 @@ from xml.etree import ElementTree
 
 try:
     from urllib.request import urlopen  # For Python 3
+    from urllib.error import URLError
 except ImportError:
     from urllib2 import urlopen  # For Python 2
+    from urllib2 import URLError
 
 # variables
 base_url = 'https://softwareupdate.vmware.com/cds/vmw-desktop/'
@@ -36,7 +38,7 @@ def core_metadata(base_url, fusion):
 
     try:
         vsus = urlopen(base_url + fusion)
-    except BaseException as e:
+    except URLError as e:
         print(e.reason)
 
     data = vsus.read()
@@ -69,7 +71,7 @@ def core_metadata(base_url, fusion):
 
     try:
         vLatest = urlopen(base_url + core[0])
-    except BaseException as e:
+    except URLError as e:
         print(e.reason)
 
     buf = StringIO( vLatest.read())

--- a/VMware Fusion/VMwareFusionCustomProcessor-test.py
+++ b/VMware Fusion/VMwareFusionCustomProcessor-test.py
@@ -14,13 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import print_function
-import urllib, urllib2, gzip
+from __future__ import absolute_import, print_function
 
-from xml.etree import ElementTree
-from StringIO import StringIO
+import gzip
+import urllib2
 from distutils.version import LooseVersion
+from StringIO import StringIO
+from xml.etree import ElementTree
 
 # variables
 base_url = 'https://softwareupdate.vmware.com/cds/vmw-desktop/'

--- a/VMware Fusion/VMwareFusionCustomProcessor-test.py
+++ b/VMware Fusion/VMwareFusionCustomProcessor-test.py
@@ -36,7 +36,7 @@ def core_metadata(base_url, fusion):
 
     try:
         vsus = urlopen(base_url + fusion)
-    except Exception as e:
+    except BaseException as e:
         print(e.reason)
 
     data = vsus.read()
@@ -69,7 +69,7 @@ def core_metadata(base_url, fusion):
 
     try:
         vLatest = urlopen(base_url + core[0])
-    except Exception as e:
+    except BaseException as e:
         print(e.reason)
 
     buf = StringIO( vLatest.read())

--- a/VMware Fusion/VMwareFusionCustomProcessor-test.py
+++ b/VMware Fusion/VMwareFusionCustomProcessor-test.py
@@ -37,7 +37,7 @@ def core_metadata(base_url, fusion):
         print(e.reason)
 
     data = vsus.read()
-    # print data
+    # print(data)
 
     try:
         metaList = ElementTree.fromstring(data)
@@ -51,7 +51,7 @@ def core_metadata(base_url, fusion):
 
     versions.sort(key=LooseVersion)
     latest = versions[-1]
-    # print latest
+    # print(latest)
 
     urls = []
     for metadata in metaList:
@@ -74,7 +74,7 @@ def core_metadata(base_url, fusion):
     buf = StringIO( vLatest.read())
     f = gzip.GzipFile(fileobj=buf)
     data = f.read()
-    # print data
+    # print(data)
 
     try:
         metadataResponse = ElementTree.fromstring(data)

--- a/VMware Fusion/VMwareFusionGuestToolsCustomProcessor-test.py
+++ b/VMware Fusion/VMwareFusionGuestToolsCustomProcessor-test.py
@@ -22,8 +22,10 @@ from xml.etree import ElementTree
 
 try:
     from urllib.request import urlopen  # For Python 3
+    from urllib.error import URLError
 except ImportError:
     from urllib2 import urlopen  # For Python 2
+    from urllib2 import URLError
 
 # variables
 base_url = 'https://softwareupdate.vmware.com/cds/vmw-desktop/'
@@ -35,7 +37,7 @@ def packages_metadata(base_url, fusion):
 
     try:
         vsus = urlopen(base_url + fusion)
-    except BaseException as e:
+    except URLError as e:
         print(e.reason)
 
     data = vsus.read()
@@ -68,7 +70,7 @@ def packages_metadata(base_url, fusion):
 
     try:
         vLatest = urlopen(base_url + packages[0])
-    except BaseException as e:
+    except URLError as e:
         print(e.reason)
 
     buf = StringIO( vLatest.read())

--- a/VMware Fusion/VMwareFusionGuestToolsCustomProcessor-test.py
+++ b/VMware Fusion/VMwareFusionGuestToolsCustomProcessor-test.py
@@ -17,9 +17,13 @@
 from __future__ import absolute_import, print_function
 
 import gzip
-import urllib2
 from StringIO import StringIO
 from xml.etree import ElementTree
+
+try:
+    from urllib.request import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 # variables
 base_url = 'https://softwareupdate.vmware.com/cds/vmw-desktop/'
@@ -27,12 +31,11 @@ fusion = 'fusion.xml'
 
 # functions
 def packages_metadata(base_url, fusion):
-    request = urllib2.Request(base_url+fusion)
     print(base_url)
 
     try:
-        vsus = urllib2.urlopen(request)
-    except URLError as e:
+        vsus = urlopen(base_url + fusion)
+    except Exception as e:
         print(e.reason)
 
     data = vsus.read()
@@ -63,11 +66,9 @@ def packages_metadata(base_url, fusion):
 
     vsus.close()
 
-    request = urllib2.Request(base_url+packages[0])
-
     try:
-        vLatest = urllib2.urlopen(request)
-    except URLError as e:
+        vLatest = urlopen(base_url + packages[0])
+    except Exception as e:
         print(e.reason)
 
     buf = StringIO( vLatest.read())

--- a/VMware Fusion/VMwareFusionGuestToolsCustomProcessor-test.py
+++ b/VMware Fusion/VMwareFusionGuestToolsCustomProcessor-test.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
+from __future__ import print_function
 import urllib, urllib2, gzip
 
 from xml.etree import ElementTree
@@ -26,12 +28,12 @@ fusion = 'fusion.xml'
 # functions
 def packages_metadata(base_url, fusion):
     request = urllib2.Request(base_url+fusion)
-    print base_url
+    print(base_url)
 
     try:
         vsus = urllib2.urlopen(request)
-    except URLError, e:
-        print e.reason
+    except URLError as e:
+        print(e.reason)
 
     data = vsus.read()
     # print data
@@ -39,7 +41,7 @@ def packages_metadata(base_url, fusion):
     try:
         metaList = ElementTree.fromstring(data)
     except ExpatData:
-        print "Unable to parse XML data from string"
+        print("Unable to parse XML data from string")
 
     versions = []
     for metadata in metaList:
@@ -57,7 +59,7 @@ def packages_metadata(base_url, fusion):
 
     matching = [s for s in urls if latest in s]
     packages = [s for s in matching if "package" in s]
-    print packages[0]
+    print(packages[0])
 
     vsus.close()
 
@@ -65,24 +67,24 @@ def packages_metadata(base_url, fusion):
 
     try:
         vLatest = urllib2.urlopen(request)
-    except URLError, e:
-        print e.reason
+    except URLError as e:
+        print(e.reason)
 
     buf = StringIO( vLatest.read())
     f = gzip.GzipFile(fileobj=buf)
     data = f.read()
     # print data
 
-    print base_url+packages[0].replace("metadata.xml.gz", "")
+    print(base_url+packages[0].replace("metadata.xml.gz", ""))
 
     try:
         metadataResponse = ElementTree.fromstring(data)
     except ExpatData:
-        print "Unable to parse XML data from string"
+        print("Unable to parse XML data from string")
 
     for elem in metadataResponse.findall('bulletin/componentList/component/relativePath'):
         # print elem.text
         # print packages[0].replace("metadata.xml.gz", elem.text)
-        print base_url+packages[0].replace("metadata.xml.gz", elem.text)
+        print(base_url+packages[0].replace("metadata.xml.gz", elem.text))
 
 packages_metadata(base_url, fusion)

--- a/VMware Fusion/VMwareFusionGuestToolsCustomProcessor-test.py
+++ b/VMware Fusion/VMwareFusionGuestToolsCustomProcessor-test.py
@@ -36,7 +36,7 @@ def packages_metadata(base_url, fusion):
         print(e.reason)
 
     data = vsus.read()
-    # print data
+    # print(data)
 
     try:
         metaList = ElementTree.fromstring(data)
@@ -50,7 +50,7 @@ def packages_metadata(base_url, fusion):
 
     versions.sort()
     latest = versions[-1]
-    # print latest
+    # print(latest)
 
     urls = []
     for metadata in metaList:
@@ -73,7 +73,7 @@ def packages_metadata(base_url, fusion):
     buf = StringIO( vLatest.read())
     f = gzip.GzipFile(fileobj=buf)
     data = f.read()
-    # print data
+    # print(data)
 
     print(base_url+packages[0].replace("metadata.xml.gz", ""))
 
@@ -83,8 +83,8 @@ def packages_metadata(base_url, fusion):
         print("Unable to parse XML data from string")
 
     for elem in metadataResponse.findall('bulletin/componentList/component/relativePath'):
-        # print elem.text
-        # print packages[0].replace("metadata.xml.gz", elem.text)
+        # print(elem.text)
+        # print(packages[0].replace("metadata.xml.gz", elem.text))
         print(base_url+packages[0].replace("metadata.xml.gz", elem.text))
 
 packages_metadata(base_url, fusion)

--- a/VMware Fusion/VMwareFusionGuestToolsCustomProcessor-test.py
+++ b/VMware Fusion/VMwareFusionGuestToolsCustomProcessor-test.py
@@ -14,12 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import print_function
-import urllib, urllib2, gzip
+from __future__ import absolute_import, print_function
 
-from xml.etree import ElementTree
+import gzip
+import urllib2
 from StringIO import StringIO
+from xml.etree import ElementTree
 
 # variables
 base_url = 'https://softwareupdate.vmware.com/cds/vmw-desktop/'

--- a/VMware Fusion/VMwareFusionGuestToolsCustomProcessor-test.py
+++ b/VMware Fusion/VMwareFusionGuestToolsCustomProcessor-test.py
@@ -35,7 +35,7 @@ def packages_metadata(base_url, fusion):
 
     try:
         vsus = urlopen(base_url + fusion)
-    except Exception as e:
+    except BaseException as e:
         print(e.reason)
 
     data = vsus.read()
@@ -68,7 +68,7 @@ def packages_metadata(base_url, fusion):
 
     try:
         vLatest = urlopen(base_url + packages[0])
-    except Exception as e:
+    except BaseException as e:
         print(e.reason)
 
     buf = StringIO( vLatest.read())

--- a/VMware Fusion/VMwareFusionGuestToolsURLProvider.py
+++ b/VMware Fusion/VMwareFusionGuestToolsURLProvider.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
+from __future__ import print_function
 import urllib, urllib2, gzip
 
 from xml.etree import ElementTree
@@ -58,8 +60,8 @@ class VMwareFusionGuestToolsURLProvider(Processor):
 
         try:
             vsus = urllib2.urlopen(request)
-        except URLError, e:
-            print e.reason
+        except URLError as e:
+            print(e.reason)
 
         data = vsus.read()
         # print data
@@ -67,7 +69,7 @@ class VMwareFusionGuestToolsURLProvider(Processor):
         try:
             metaList = ElementTree.fromstring(data)
         except ExpatData:
-            print "Unable to parse XML data from string"
+            print("Unable to parse XML data from string")
 
         versions = []
         for metadata in metaList:
@@ -93,8 +95,8 @@ class VMwareFusionGuestToolsURLProvider(Processor):
 
         try:
             vLatest = urllib2.urlopen(request)
-        except URLError, e:
-            print e.reason
+        except URLError as e:
+            print(e.reason)
 
         buf = StringIO( vLatest.read())
         f = gzip.GzipFile(fileobj=buf)
@@ -104,7 +106,7 @@ class VMwareFusionGuestToolsURLProvider(Processor):
         try:
             metadataResponse = ElementTree.fromstring(data)
         except ExpatData:
-            print "Unable to parse XML data from string"
+            print("Unable to parse XML data from string")
 
         return base_url+packages[0].replace("metadata.xml.gz", "")+guest_tool
 

--- a/VMware Fusion/VMwareFusionGuestToolsURLProvider.py
+++ b/VMware Fusion/VMwareFusionGuestToolsURLProvider.py
@@ -14,12 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import print_function
-import urllib, urllib2, gzip
+from __future__ import absolute_import, print_function
 
-from xml.etree import ElementTree
+import gzip
+import urllib2
 from StringIO import StringIO
+from xml.etree import ElementTree
+
 from autopkglib import Processor, ProcessorError
 
 __all__ = ["VMwareFusionGuestToolsURLProvider"]
@@ -127,4 +128,3 @@ class VMwareFusionGuestToolsURLProvider(Processor):
 if __name__ == "__main__":
     processor = VMwareFusionGuestToolsURLProvider()
     processor.execute_shell()
-

--- a/VMware Fusion/VMwareFusionGuestToolsURLProvider.py
+++ b/VMware Fusion/VMwareFusionGuestToolsURLProvider.py
@@ -57,7 +57,7 @@ class VMwareFusionGuestToolsURLProvider(Processor):
 
     def packages_metadata(self, base_url, guest_tool, product_name):
         request = urllib2.Request(base_url+product_name)
-        # print base_url
+        # print(base_url)
 
         try:
             vsus = urllib2.urlopen(request)
@@ -65,7 +65,7 @@ class VMwareFusionGuestToolsURLProvider(Processor):
             print(e.reason)
 
         data = vsus.read()
-        # print data
+        # print(data)
 
         try:
             metaList = ElementTree.fromstring(data)
@@ -79,7 +79,7 @@ class VMwareFusionGuestToolsURLProvider(Processor):
 
         versions.sort()
         latest = versions[-1]
-        # print latest
+        # print(latest)
 
         urls = []
         for metadata in metaList:
@@ -88,7 +88,7 @@ class VMwareFusionGuestToolsURLProvider(Processor):
 
         matching = [s for s in urls if latest in s]
         packages = [s for s in matching if "packages" in s]
-        # print packages[0]
+        # print(packages[0])
 
         vsus.close()
 
@@ -102,7 +102,7 @@ class VMwareFusionGuestToolsURLProvider(Processor):
         buf = StringIO( vLatest.read())
         f = gzip.GzipFile(fileobj=buf)
         data = f.read()
-        # print data
+        # print(data)
 
         try:
             metadataResponse = ElementTree.fromstring(data)
@@ -113,7 +113,7 @@ class VMwareFusionGuestToolsURLProvider(Processor):
 
         # relativePath = metadataResponse.find("bulletin/componentList/component/relativePath")
         #for elem in metadataResponse.findall('bulletin/componentList/component/relativePath'):
-            # print elem.text
+            # print(elem.text)
         #    return base_url+packages[0].replace("metadata.xml.gz", elem.text)
 
     def main(self):

--- a/VMware Fusion/VMwareFusionGuestToolsURLProvider.py
+++ b/VMware Fusion/VMwareFusionGuestToolsURLProvider.py
@@ -64,7 +64,7 @@ class VMwareFusionGuestToolsURLProvider(Processor):
 
         try:
             vsus = urlopen(base_url + product_name)
-        except Exception as e:
+        except BaseException as e:
             print(e.reason)
 
         data = vsus.read()
@@ -97,7 +97,7 @@ class VMwareFusionGuestToolsURLProvider(Processor):
 
         try:
             vLatest = urlopen(base_url + packages[0])
-        except Exception as e:
+        except BaseException as e:
             print(e.reason)
 
         buf = StringIO( vLatest.read())

--- a/VMware Fusion/VMwareFusionGuestToolsURLProvider.py
+++ b/VMware Fusion/VMwareFusionGuestToolsURLProvider.py
@@ -17,11 +17,15 @@
 from __future__ import absolute_import, print_function
 
 import gzip
-import urllib2
 from StringIO import StringIO
 from xml.etree import ElementTree
 
 from autopkglib import Processor, ProcessorError
+
+try:
+    from urllib.request import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["VMwareFusionGuestToolsURLProvider"]
 
@@ -56,12 +60,11 @@ class VMwareFusionGuestToolsURLProvider(Processor):
     __doc__ = description
 
     def packages_metadata(self, base_url, guest_tool, product_name):
-        request = urllib2.Request(base_url+product_name)
         # print(base_url)
 
         try:
-            vsus = urllib2.urlopen(request)
-        except URLError as e:
+            vsus = urlopen(base_url + product_name)
+        except Exception as e:
             print(e.reason)
 
         data = vsus.read()
@@ -92,11 +95,9 @@ class VMwareFusionGuestToolsURLProvider(Processor):
 
         vsus.close()
 
-        request = urllib2.Request(base_url+packages[0])
-
         try:
-            vLatest = urllib2.urlopen(request)
-        except URLError as e:
+            vLatest = urlopen(base_url + packages[0])
+        except Exception as e:
             print(e.reason)
 
         buf = StringIO( vLatest.read())

--- a/VMware Fusion/VMwareFusionGuestToolsURLProvider.py
+++ b/VMware Fusion/VMwareFusionGuestToolsURLProvider.py
@@ -24,8 +24,10 @@ from autopkglib import Processor, ProcessorError
 
 try:
     from urllib.request import urlopen  # For Python 3
+    from urllib.error import URLError
 except ImportError:
     from urllib2 import urlopen  # For Python 2
+    from urllib2 import URLError
 
 __all__ = ["VMwareFusionGuestToolsURLProvider"]
 
@@ -64,7 +66,7 @@ class VMwareFusionGuestToolsURLProvider(Processor):
 
         try:
             vsus = urlopen(base_url + product_name)
-        except BaseException as e:
+        except URLError as e:
             print(e.reason)
 
         data = vsus.read()
@@ -97,7 +99,7 @@ class VMwareFusionGuestToolsURLProvider(Processor):
 
         try:
             vLatest = urlopen(base_url + packages[0])
-        except BaseException as e:
+        except URLError as e:
             print(e.reason)
 
         buf = StringIO( vLatest.read())

--- a/VMware Fusion/VMwareFusionURLProvider.py
+++ b/VMware Fusion/VMwareFusionURLProvider.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
+from __future__ import print_function
 import urllib, urllib2, gzip
 
 from xml.etree import ElementTree
@@ -58,8 +60,8 @@ class VMwareFusionURLProvider(Processor):
 
         try:
             vsus = urllib2.urlopen(request)
-        except URLError, e:
-            print e.reason
+        except URLError as e:
+            print(e.reason)
 
         data = vsus.read()
         # print data
@@ -67,7 +69,7 @@ class VMwareFusionURLProvider(Processor):
         try:
             metaList = ElementTree.fromstring(data)
         except ExpatData:
-            print "Unable to parse XML data from string"
+            print("Unable to parse XML data from string")
 
         versions = []
         for metadata in metaList:
@@ -93,8 +95,8 @@ class VMwareFusionURLProvider(Processor):
 
         try:
             vLatest = urllib2.urlopen(request)
-        except URLError, e:
-            print e.reason
+        except URLError as e:
+            print(e.reason)
 
         buf = StringIO( vLatest.read())
         f = gzip.GzipFile(fileobj=buf)
@@ -104,7 +106,7 @@ class VMwareFusionURLProvider(Processor):
         try:
             metadataResponse = ElementTree.fromstring(data)
         except ExpatData:
-            print "Unable to parse XML data from string"
+            print("Unable to parse XML data from string")
 
         relativePath = metadataResponse.find("bulletin/componentList/component/relativePath")
         # print core[0].replace("metadata.xml.gz", relativePath.text)

--- a/VMware Fusion/VMwareFusionURLProvider.py
+++ b/VMware Fusion/VMwareFusionURLProvider.py
@@ -57,7 +57,7 @@ class VMwareFusionURLProvider(Processor):
 
     def core_metadata(self, base_url, product_name):
         request = urllib2.Request(base_url+product_name)
-        # print base_url
+        # print(base_url)
 
         try:
             vsus = urllib2.urlopen(request)
@@ -65,7 +65,7 @@ class VMwareFusionURLProvider(Processor):
             print(e.reason)
 
         data = vsus.read()
-        # print data
+        # print(data)
 
         try:
             metaList = ElementTree.fromstring(data)
@@ -79,7 +79,7 @@ class VMwareFusionURLProvider(Processor):
 
         versions.sort(key=LooseVersion)
         self.latest = versions[-1]
-        # print latest
+        # print(latest)
 
         urls = []
         for metadata in metaList:
@@ -88,7 +88,7 @@ class VMwareFusionURLProvider(Processor):
 
         matching = [s for s in urls if self.latest in s]
         core = [s for s in matching if "core" in s]
-        # print core[0]
+        # print(core[0])
 
         vsus.close()
 
@@ -102,7 +102,7 @@ class VMwareFusionURLProvider(Processor):
         buf = StringIO( vLatest.read())
         f = gzip.GzipFile(fileobj=buf)
         data = f.read()
-        # print data
+        # print(data)
 
         try:
             metadataResponse = ElementTree.fromstring(data)
@@ -110,7 +110,7 @@ class VMwareFusionURLProvider(Processor):
             print("Unable to parse XML data from string")
 
         relativePath = metadataResponse.find("bulletin/componentList/component/relativePath")
-        # print core[0].replace("metadata.xml.gz", relativePath.text)
+        # print(core[0].replace("metadata.xml.gz", relativePath.text))
         return base_url+core[0].replace("metadata.xml.gz", relativePath.text)
 
     def main(self):

--- a/VMware Fusion/VMwareFusionURLProvider.py
+++ b/VMware Fusion/VMwareFusionURLProvider.py
@@ -64,7 +64,7 @@ class VMwareFusionURLProvider(Processor):
 
         try:
             vsus = urlopen(base_url + product_name)
-        except Exception as e:
+        except BaseException as e:
             print(e.reason)
 
         data = vsus.read()
@@ -97,7 +97,7 @@ class VMwareFusionURLProvider(Processor):
 
         try:
             vLatest = urlopen(base_url + core[0])
-        except Exception as e:
+        except BaseException as e:
             print(e.reason)
 
         buf = StringIO( vLatest.read())

--- a/VMware Fusion/VMwareFusionURLProvider.py
+++ b/VMware Fusion/VMwareFusionURLProvider.py
@@ -14,14 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import print_function
-import urllib, urllib2, gzip
+from __future__ import absolute_import, print_function
 
-from xml.etree import ElementTree
-from StringIO import StringIO
-from autopkglib import Processor, ProcessorError
+import gzip
+import urllib2
 from distutils.version import LooseVersion
+from StringIO import StringIO
+from xml.etree import ElementTree
+
+from autopkglib import Processor, ProcessorError
 
 __all__ = ["VMwareFusionURLProvider"]
 

--- a/VMware Fusion/VMwareFusionURLProvider.py
+++ b/VMware Fusion/VMwareFusionURLProvider.py
@@ -25,8 +25,10 @@ from autopkglib import Processor, ProcessorError
 
 try:
     from urllib.request import urlopen  # For Python 3
+    from urllib.error import URLError
 except ImportError:
     from urllib2 import urlopen  # For Python 2
+    from urllib2 import URLError
 
 __all__ = ["VMwareFusionURLProvider"]
 
@@ -64,7 +66,7 @@ class VMwareFusionURLProvider(Processor):
 
         try:
             vsus = urlopen(base_url + product_name)
-        except BaseException as e:
+        except URLError as e:
             print(e.reason)
 
         data = vsus.read()
@@ -97,7 +99,7 @@ class VMwareFusionURLProvider(Processor):
 
         try:
             vLatest = urlopen(base_url + core[0])
-        except BaseException as e:
+        except URLError as e:
             print(e.reason)
 
         buf = StringIO( vLatest.read())

--- a/VMware Fusion/VMwareFusionURLProvider.py
+++ b/VMware Fusion/VMwareFusionURLProvider.py
@@ -17,12 +17,16 @@
 from __future__ import absolute_import, print_function
 
 import gzip
-import urllib2
 from distutils.version import LooseVersion
 from StringIO import StringIO
 from xml.etree import ElementTree
 
 from autopkglib import Processor, ProcessorError
+
+try:
+    from urllib.request import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["VMwareFusionURLProvider"]
 
@@ -56,12 +60,11 @@ class VMwareFusionURLProvider(Processor):
     __doc__ = description
 
     def core_metadata(self, base_url, product_name):
-        request = urllib2.Request(base_url+product_name)
         # print(base_url)
 
         try:
-            vsus = urllib2.urlopen(request)
-        except URLError as e:
+            vsus = urlopen(base_url + product_name)
+        except Exception as e:
             print(e.reason)
 
         data = vsus.read()
@@ -92,11 +95,9 @@ class VMwareFusionURLProvider(Processor):
 
         vsus.close()
 
-        request = urllib2.Request(base_url+core[0])
-
         try:
-            vLatest = urllib2.urlopen(request)
-        except URLError as e:
+            vLatest = urlopen(base_url + core[0])
+        except Exception as e:
             print(e.reason)
 
         buf = StringIO( vLatest.read())


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later (including `StringIO`), but this should catch the low-hanging fruit right now.