### PR TITLE
AutoPkg 2.0/Python3 compatibility for VMwareFusion recipes

### DIFF
--- a/VMware Fusion/VMwareFusion.download.recipe
+++ b/VMware Fusion/VMwareFusion.download.recipe
@@ -12,7 +12,7 @@
 		<string>com.vmware.fusion</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.5</string>
+	<string>1.4.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/VMware Fusion/VMwareFusion.jss.recipe
+++ b/VMware Fusion/VMwareFusion.jss.recipe
@@ -19,7 +19,7 @@
 		<!--<key>ARB_GROUP_NAME</key><string>arbitrary</string>-->
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.5</string>
+	<string>1.4.1</string>
 	<key>ParentRecipe</key>
 	<string>com.justinrummel.pkg.VMwareFusion</string>
 	<key>Process</key>

--- a/VMware Fusion/VMwareFusion.munki.recipe
+++ b/VMware Fusion/VMwareFusion.munki.recipe
@@ -31,7 +31,7 @@
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.5</string>
+	<string>1.4.1</string>
 	<key>ParentRecipe</key>
 	<string>com.justinrummel.download.VMwareFusion</string>
 	<key>Process</key>

--- a/VMware Fusion/VMwareFusion.pkg.munki.recipe
+++ b/VMware Fusion/VMwareFusion.pkg.munki.recipe
@@ -31,7 +31,7 @@
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.5</string>
+	<string>1.4.1</string>
 	<key>ParentRecipe</key>
 	<string>com.justinrummel.pkg.VMwareFusion</string>
 	<key>Process</key>

--- a/VMware Fusion/VMwareFusion.pkg.recipe
+++ b/VMware Fusion/VMwareFusion.pkg.recipe
@@ -12,7 +12,7 @@
 		<string>com.vmware.fusion</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.5</string>
+	<string>1.4.1</string>
 	<key>ParentRecipe</key>
 	<string>com.justinrummel.download.VMwareFusion</string>
 	<key>Process</key>

--- a/VMware Fusion/VMwareFusionURLProvider.py
+++ b/VMware Fusion/VMwareFusionURLProvider.py
@@ -34,28 +34,23 @@ __all__ = ["VMwareFusionURLProvider"]
 
 
 # variables
-VMWARE_BASE_URL = 'https://softwareupdate.vmware.com/cds/vmw-desktop/'
-FUSION = 'fusion.xml'
+VMWARE_BASE_URL = "https://softwareupdate.vmware.com/cds/vmw-desktop/"
+FUSION = "fusion.xml"
+
 
 class VMwareFusionURLProvider(Processor):
     description = "Provides URL to the latest VMware Fusion update release."
     input_variables = {
-        "product_name": {
-            "required": False,
-            "description":
-                "Default is '%s." % FUSION,
-        },
+        "product_name": {"required": False, "description": "Default is '%s." % FUSION},
         "base_url": {
             "required": False,
             "description": "Default is '%s." % VMWARE_BASE_URL,
         },
     }
     output_variables = {
-        "url": {
-            "description": "URL to the latest VMware Fusion update release.",
-        },
+        "url": {"description": "URL to the latest VMware Fusion update release."},
         "version": {
-            "description": "Version to the latest VMware Fusion update release.",
+            "description": "Version to the latest VMware Fusion update release."
         },
     }
 
@@ -102,7 +97,7 @@ class VMwareFusionURLProvider(Processor):
         except URLError as e:
             print(e.reason)
 
-        buf = StringIO( vLatest.read())
+        buf = StringIO(vLatest.read())
         f = gzip.GzipFile(fileobj=buf)
         data = f.read()
         # print(data)
@@ -112,9 +107,11 @@ class VMwareFusionURLProvider(Processor):
         except ExpatData:
             print("Unable to parse XML data from string")
 
-        relativePath = metadataResponse.find("bulletin/componentList/component/relativePath")
+        relativePath = metadataResponse.find(
+            "bulletin/componentList/component/relativePath"
+        )
         # print(core[0].replace("metadata.xml.gz", relativePath.text))
-        return base_url+core[0].replace("metadata.xml.gz", relativePath.text)
+        return base_url + core[0].replace("metadata.xml.gz", relativePath.text)
 
     def main(self):
         # Determine product_name, and base_url.
@@ -125,6 +122,7 @@ class VMwareFusionURLProvider(Processor):
         self.output("Found URL %s" % self.env["url"])
         self.env["version"] = self.latest
         self.output("Found Version %s" % self.env["version"])
+
 
 if __name__ == "__main__":
     processor = VMwareFusionURLProvider()

--- a/VMware Fusion/VMwareFusionURLProvider.py
+++ b/VMware Fusion/VMwareFusionURLProvider.py
@@ -62,7 +62,6 @@ class VMwareFusionURLProvider(URLGetter):
         """Given a base URL, product name, and major version, produce the
         product download URL and latest version.
         """
-
         vsus = self.download(base_url + product_name, text=True)
 
         try:
@@ -92,9 +91,13 @@ class VMwareFusionURLProvider(URLGetter):
         core = [s for s in matching if "core" in s]
         self.output("Core value: {}".format(core), verbose_level=2)
         self.output("URL: {}".format(base_url + core[0]))
-        temp_file = os.path.join(
-            self.env["RECIPE_CACHE_DIR"], "downloads", "metadata.xml.gz"
-        )
+        download_dir = os.path.join(self.env["RECIPE_CACHE_DIR"], "downloads")
+        try:
+            os.makedirs(download_dir)
+        except os.error:
+            # Directory already exists
+            pass
+        temp_file = os.path.join(download_dir, "metadata.xml.gz")
         vLatest = self.download_to_file(base_url + core[0], temp_file)
         try:
             with gzip.open(vLatest, "rb") as f:

--- a/VMware Fusion/VMwareFusionURLProvider.py
+++ b/VMware Fusion/VMwareFusionURLProvider.py
@@ -17,6 +17,7 @@
 
 from __future__ import absolute_import, print_function
 
+import os
 import gzip
 from distutils.version import LooseVersion
 from xml.etree import ElementTree
@@ -38,10 +39,7 @@ class VMwareFusionURLProvider(URLGetter):
 
     description = "Provides URL to the latest VMware Fusion update release."
     input_variables = {
-        "product_name": {
-            "required": False,
-            "description": "Default is '%s'." % FUSION,
-        },
+        "product_name": {"required": False, "description": "Default is '%s'." % FUSION},
         "base_url": {
             "required": False,
             "description": "Default is '%s." % VMWARE_BASE_URL,
@@ -66,7 +64,6 @@ class VMwareFusionURLProvider(URLGetter):
         """
 
         vsus = self.download(base_url + product_name, text=True)
-        # self.output("Metadata fetch result: {}".format(vsus), verbose_level=2)
 
         try:
             metaList = ElementTree.fromstring(vsus)
@@ -95,12 +92,10 @@ class VMwareFusionURLProvider(URLGetter):
         core = [s for s in matching if "core" in s]
         self.output("Core value: {}".format(core), verbose_level=2)
         self.output("URL: {}".format(base_url + core[0]))
-        vLatest = self.download(base_url + core[0], text=False)
-        print("***vLatest: {}".format(vLatest))
-        # buf = StringIO(vLatest.read())
-        # f = gzip.GzipFile(fileobj=buf)
-        # data = f.read()
-        # # print(data)
+        temp_file = os.path.join(
+            self.env["RECIPE_CACHE_DIR"], "downloads", "metadata.xml.gz"
+        )
+        vLatest = self.download_to_file(base_url + core[0], temp_file)
         try:
             with gzip.open(vLatest, "rb") as f:
                 data = f.read()


### PR DESCRIPTION
The current recipes don't work in AutoPkg 2.0, so this adds Python 3 compatibility for the URLProvider. It uses the new URLGetter processor parent class to allow access to the `download_to_file()` function, which simplifies the work in the processor considerably.

This works in both 1.4.1 and 2.0b3.

### AutoPkg 1.4.1:
```
$ ./autopkg run -vvvv VMwareFusion.download
Processing VMwareFusion.download...
WARNING: VMwareFusion.download is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
{'AUTOPKG_VERSION': u'2.0',
 u'CACHE_DIR': u'/Users/Shared/AutoPkg/Cache',
 u'MUNKI_REPO': u'/Users/Shared/munki_repo',
 u'NAME': u'com.vmware.fusion',
 'PARENT_RECIPES': [],
 'RECIPE_CACHE_DIR': u'/Users/Shared/AutoPkg/Cache/com.justinrummel.download.VMwareFusion',
 'RECIPE_DIR': u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.justinrummel-recipes/VMware Fusion',
 u'RECIPE_OVERRIDE_DIRS': [u'/Users/Shared/AutoPkg/RecipeOverrides'],
 'RECIPE_PATH': u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.justinrummel-recipes/VMware Fusion/VMwareFusion.download.recipe',
 u'RECIPE_REPOS': {u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.jessepeterson-recipes': {u'URL': u'https://github.com/autopkg/jessepeterson-recipes'},
                   u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.justinrummel-recipes': {u'URL': u'https://github.com/autopkg/justinrummel-recipes'},
                   u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.recipes': {u'URL': u'https://github.com/autopkg/recipes'},
                   u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes': {u'URL': u'https://github.com/autopkg/rtrouton-recipes'},
                   u'/Users/Shared/AutoPkg/RecipeRepos/com.github.facebook.Recipes-for-AutoPkg': {u'URL': u'https://github.com/facebook/Recipes-for-AutoPkg.git'}},
 u'RECIPE_REPO_DIR': u'/Users/Shared/AutoPkg/RecipeRepos',
 u'RECIPE_SEARCH_DIRS': [u'.',
                         u'~/Library/AutoPkg/Recipes',
                         u'/Library/AutoPkg/Recipes',
                         u'/Users/Shared/AutoPkg/Recipes',
                         u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.recipes',
                         u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.justinrummel-recipes',
                         u'/Users/Shared/AutoPkg/RecipeRepos/com.github.facebook.Recipes-for-AutoPkg',
                         u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.jessepeterson-recipes',
                         u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes'],
 'verbose': 4}
VMwareFusionURLProvider
{'Input': {'product_name': u'fusion.xml'}}
VMwareFusionURLProvider: Fetching fusion.xml from https://softwareupdate.vmware.com/cds/vmw-desktop/fusion.xml
VMwareFusionURLProvider: Found version: 11.1.0 with URL: fusion/11.1.0/13668589/packages/metadata.xml.gz
VMwareFusionURLProvider: Found version: 11.0.0 with URL: fusion/11.0.0/10120384/core/metadata.xml.gz
VMwareFusionURLProvider: Found version: 11.0.0 with URL: fusion/11.0.3/12992109/core/metadata.xml.gz
VMwareFusionURLProvider: Found version: 11.0.0 with URL: fusion/11.0.2/10952296/core/metadata.xml.gz
VMwareFusionURLProvider: Found version: 11.0.3 with URL: fusion/11.0.3/12992109/packages/metadata.xml.gz
VMwareFusionURLProvider: Found version: 11.5.0 with URL: fusion/11.5.1/15018442/core/metadata.xml.gz
VMwareFusionURLProvider: Found version: 11.0.0 with URL: fusion/11.0.1/10738065/core/metadata.xml.gz
VMwareFusionURLProvider: Found version: 11.0.0 with URL: fusion/11.1.0/13668589/core/metadata.xml.gz
VMwareFusionURLProvider: Found version: 11.5.0 with URL: fusion/11.5.0/14634996/core/metadata.xml.gz
VMwareFusionURLProvider: Found version: 11.0.2 with URL: fusion/11.0.2/10952296/packages/metadata.xml.gz
VMwareFusionURLProvider: Found version: 11.0.1 with URL: fusion/11.0.1/10738065/packages/metadata.xml.gz
VMwareFusionURLProvider: Found version: 11.0.0 with URL: fusion/11.0.0/10120384/packages/metadata.xml.gz
VMwareFusionURLProvider: Latest version URL suffix: fusion/11.5.1/15018442/core/metadata.xml.gz
VMwareFusionURLProvider: URL: https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/11.5.1/15018442/core/metadata.xml.gz
VMwareFusionURLProvider: Found URL: https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/11.5.1/15018442/core/com.vmware.fusion.zip.tar
VMwareFusionURLProvider: Found Version: 11.5.1
{'Output': {'url': 'https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/11.5.1/15018442/core/com.vmware.fusion.zip.tar',
            'version': '11.5.1'}}
URLDownloader
{'Input': {'filename': u'com.vmware.fusion.zip.tar',
           'url': 'https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/11.5.1/15018442/core/com.vmware.fusion.zip.tar'}}
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 05 Nov 2019 05:58:32 GMT
URLDownloader: Storing new ETag header: "d4d8324c65b7fe87e5605763a8189b80:1573582460.573331"
URLDownloader: Downloaded /Users/Shared/AutoPkg/Cache/com.justinrummel.download.VMwareFusion/downloads/com.vmware.fusion.zip.tar
{'Output': {'download_changed': True,
            'etag': '"d4d8324c65b7fe87e5605763a8189b80:1573582460.573331"',
            'last_modified': 'Tue, 05 Nov 2019 05:58:32 GMT',
            'pathname': u'/Users/Shared/AutoPkg/Cache/com.justinrummel.download.VMwareFusion/downloads/com.vmware.fusion.zip.tar',
            'url_downloader_summary_result': {'data': {'download_path': u'/Users/Shared/AutoPkg/Cache/com.justinrummel.download.VMwareFusion/downloads/com.vmware.fusion.zip.tar'},
                                              'summary_text': 'The following new items were downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
{'AUTOPKG_VERSION': u'2.0',
 u'CACHE_DIR': u'/Users/Shared/AutoPkg/Cache',
 'CHECK_FILESIZE_ONLY': False,
 'CURL_PATH': '/usr/bin/curl',
 u'MUNKI_REPO': u'/Users/Shared/munki_repo',
 u'NAME': u'com.vmware.fusion',
 'PARENT_RECIPES': [],
 'RECIPE_CACHE_DIR': u'/Users/Shared/AutoPkg/Cache/com.justinrummel.download.VMwareFusion',
 'RECIPE_DIR': u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.justinrummel-recipes/VMware Fusion',
 u'RECIPE_OVERRIDE_DIRS': [u'/Users/Shared/AutoPkg/RecipeOverrides'],
 'RECIPE_PATH': u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.justinrummel-recipes/VMware Fusion/VMwareFusion.download.recipe',
 u'RECIPE_REPOS': {u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.jessepeterson-recipes': {u'URL': u'https://github.com/autopkg/jessepeterson-recipes'},
                   u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.justinrummel-recipes': {u'URL': u'https://github.com/autopkg/justinrummel-recipes'},
                   u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.recipes': {u'URL': u'https://github.com/autopkg/recipes'},
                   u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes': {u'URL': u'https://github.com/autopkg/rtrouton-recipes'},
                   u'/Users/Shared/AutoPkg/RecipeRepos/com.github.facebook.Recipes-for-AutoPkg': {u'URL': u'https://github.com/facebook/Recipes-for-AutoPkg.git'}},
 u'RECIPE_REPO_DIR': u'/Users/Shared/AutoPkg/RecipeRepos',
 u'RECIPE_SEARCH_DIRS': [u'.',
                         u'~/Library/AutoPkg/Recipes',
                         u'/Library/AutoPkg/Recipes',
                         u'/Users/Shared/AutoPkg/Recipes',
                         u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.recipes',
                         u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.justinrummel-recipes',
                         u'/Users/Shared/AutoPkg/RecipeRepos/com.github.facebook.Recipes-for-AutoPkg',
                         u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.jessepeterson-recipes',
                         u'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes'],
 'download_changed': True,
 'etag': '"d4d8324c65b7fe87e5605763a8189b80:1573582460.573331"',
 u'filename': u'com.vmware.fusion.zip.tar',
 'last_modified': 'Tue, 05 Nov 2019 05:58:32 GMT',
 'pathname': u'/Users/Shared/AutoPkg/Cache/com.justinrummel.download.VMwareFusion/downloads/com.vmware.fusion.zip.tar',
 'prefetch_filename': False,
 u'product_name': u'fusion.xml',
 'url': 'https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/11.5.1/15018442/core/com.vmware.fusion.zip.tar',
 'url_downloader_summary_result': {'data': {'download_path': u'/Users/Shared/AutoPkg/Cache/com.justinrummel.download.VMwareFusion/downloads/com.vmware.fusion.zip.tar'},
                                   'summary_text': 'The following new items were downloaded:'},
 'verbose': 4,
 'version': '11.5.1'}
Receipt written to /Users/Shared/AutoPkg/Cache/com.justinrummel.download.VMwareFusion/receipts/VMwareFusion-receipt-20191203-124909.plist

The following new items were downloaded:
    Download Path
    -------------
    /Users/Shared/AutoPkg/Cache/com.justinrummel.download.VMwareFusion/downloads/com.vmware.fusion.zip.tar
```

### AutoPkg 2.0b3:
```
$ ./autopkg run -vvvv VMwareFusion.download
Processing VMwareFusion.download...
WARNING: VMwareFusion.download is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
{'AUTOPKG_VERSION': '2.0.1',
 'CACHE_DIR': '/Users/Shared/AutoPkg/Cache',
 'MUNKI_REPO': '/Users/Shared/munki_repo',
 'NAME': 'com.vmware.fusion',
 'PARENT_RECIPES': [],
 'RECIPE_CACHE_DIR': '/Users/Shared/AutoPkg/Cache/com.justinrummel.download.VMwareFusion',
 'RECIPE_DIR': '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.justinrummel-recipes/VMware '
               'Fusion',
 'RECIPE_OVERRIDE_DIRS': ['/Users/Shared/AutoPkg/RecipeOverrides'],
 'RECIPE_PATH': '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.justinrummel-recipes/VMware '
                'Fusion/VMwareFusion.download.recipe',
 'RECIPE_REPOS': {'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.jessepeterson-recipes': {'URL': 'https://github.com/autopkg/jessepeterson-recipes'},
                  '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.justinrummel-recipes': {'URL': 'https://github.com/autopkg/justinrummel-recipes'},
                  '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.recipes': {'URL': 'https://github.com/autopkg/recipes'},
                  '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes': {'URL': 'https://github.com/autopkg/rtrouton-recipes'},
                  '/Users/Shared/AutoPkg/RecipeRepos/com.github.facebook.Recipes-for-AutoPkg': {'URL': 'https://github.com/facebook/Recipes-for-AutoPkg.git'}},
 'RECIPE_REPO_DIR': '/Users/Shared/AutoPkg/RecipeRepos',
 'RECIPE_SEARCH_DIRS': ['.',
                        '~/Library/AutoPkg/Recipes',
                        '/Library/AutoPkg/Recipes',
                        '/Users/Shared/AutoPkg/Recipes',
                        '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.recipes',
                        '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.justinrummel-recipes',
                        '/Users/Shared/AutoPkg/RecipeRepos/com.github.facebook.Recipes-for-AutoPkg',
                        '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.jessepeterson-recipes',
                        '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes'],
 'verbose': 4}
VMwareFusionURLProvider
{'Input': {'product_name': 'fusion.xml'}}
VMwareFusionURLProvider: Fetching fusion.xml from https://softwareupdate.vmware.com/cds/vmw-desktop/fusion.xml
VMwareFusionURLProvider: Curl command: ['/usr/bin/curl', '--compressed', '--location', 'https://softwareupdate.vmware.com/cds/vmw-desktop/fusion.xml']
VMwareFusionURLProvider: Found version: 11.1.0 with URL: fusion/11.1.0/13668589/packages/metadata.xml.gz
VMwareFusionURLProvider: Found version: 11.0.0 with URL: fusion/11.0.0/10120384/core/metadata.xml.gz
VMwareFusionURLProvider: Found version: 11.0.0 with URL: fusion/11.0.3/12992109/core/metadata.xml.gz
VMwareFusionURLProvider: Found version: 11.0.0 with URL: fusion/11.0.2/10952296/core/metadata.xml.gz
VMwareFusionURLProvider: Found version: 11.0.3 with URL: fusion/11.0.3/12992109/packages/metadata.xml.gz
VMwareFusionURLProvider: Found version: 11.5.0 with URL: fusion/11.5.1/15018442/core/metadata.xml.gz
VMwareFusionURLProvider: Found version: 11.0.0 with URL: fusion/11.0.1/10738065/core/metadata.xml.gz
VMwareFusionURLProvider: Found version: 11.0.0 with URL: fusion/11.1.0/13668589/core/metadata.xml.gz
VMwareFusionURLProvider: Found version: 11.5.0 with URL: fusion/11.5.0/14634996/core/metadata.xml.gz
VMwareFusionURLProvider: Found version: 11.0.2 with URL: fusion/11.0.2/10952296/packages/metadata.xml.gz
VMwareFusionURLProvider: Found version: 11.0.1 with URL: fusion/11.0.1/10738065/packages/metadata.xml.gz
VMwareFusionURLProvider: Found version: 11.0.0 with URL: fusion/11.0.0/10120384/packages/metadata.xml.gz
VMwareFusionURLProvider: Latest version URL suffix: fusion/11.5.1/15018442/core/metadata.xml.gz
VMwareFusionURLProvider: URL: https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/11.5.1/15018442/core/metadata.xml.gz
VMwareFusionURLProvider: Curl command: ['/usr/bin/curl', '--compressed', '--location', 'https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/11.5.1/15018442/core/metadata.xml.gz', '-o', '/Users/Shared/AutoPkg/Cache/com.justinrummel.download.VMwareFusion/downloads/metadata.xml.gz']
VMwareFusionURLProvider: Found URL: https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/11.5.1/15018442/core/com.vmware.fusion.zip.tar
VMwareFusionURLProvider: Found Version: 11.5.1
{'Output': {'url': 'https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/11.5.1/15018442/core/com.vmware.fusion.zip.tar',
            'version': '11.5.1'}}
URLDownloader
{'Input': {'filename': 'com.vmware.fusion.zip.tar',
           'url': 'https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/11.5.1/15018442/core/com.vmware.fusion.zip.tar'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Curl command: ['/usr/bin/curl', '--silent', '--show-error', '--no-buffer', '--dump-header', '-', '--speed-time', '30', '--location', '--url', 'https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/11.5.1/15018442/core/com.vmware.fusion.zip.tar', '--fail', '--output', '/Users/Shared/AutoPkg/Cache/com.justinrummel.download.VMwareFusion/downloads/tmpa51ugurq']
URLDownloader: Storing new Last-Modified header: Tue, 05 Nov 2019 05:58:32 GMT
URLDownloader: Storing new ETag header: "d4d8324c65b7fe87e5605763a8189b80:1573582460.573331"
URLDownloader: Downloaded /Users/Shared/AutoPkg/Cache/com.justinrummel.download.VMwareFusion/downloads/com.vmware.fusion.zip.tar
{'Output': {'download_changed': True,
            'etag': '"d4d8324c65b7fe87e5605763a8189b80:1573582460.573331"',
            'last_modified': 'Tue, 05 Nov 2019 05:58:32 GMT',
            'pathname': '/Users/Shared/AutoPkg/Cache/com.justinrummel.download.VMwareFusion/downloads/com.vmware.fusion.zip.tar',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/Shared/AutoPkg/Cache/com.justinrummel.download.VMwareFusion/downloads/com.vmware.fusion.zip.tar'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
{'AUTOPKG_VERSION': '2.0.1',
 'CACHE_DIR': '/Users/Shared/AutoPkg/Cache',
 'CHECK_FILESIZE_ONLY': False,
 'MUNKI_REPO': '/Users/Shared/munki_repo',
 'NAME': 'com.vmware.fusion',
 'PARENT_RECIPES': [],
 'RECIPE_CACHE_DIR': '/Users/Shared/AutoPkg/Cache/com.justinrummel.download.VMwareFusion',
 'RECIPE_DIR': '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.justinrummel-recipes/VMware '
               'Fusion',
 'RECIPE_OVERRIDE_DIRS': ['/Users/Shared/AutoPkg/RecipeOverrides'],
 'RECIPE_PATH': '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.justinrummel-recipes/VMware '
                'Fusion/VMwareFusion.download.recipe',
 'RECIPE_REPOS': {'/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.jessepeterson-recipes': {'URL': 'https://github.com/autopkg/jessepeterson-recipes'},
                  '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.justinrummel-recipes': {'URL': 'https://github.com/autopkg/justinrummel-recipes'},
                  '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.recipes': {'URL': 'https://github.com/autopkg/recipes'},
                  '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes': {'URL': 'https://github.com/autopkg/rtrouton-recipes'},
                  '/Users/Shared/AutoPkg/RecipeRepos/com.github.facebook.Recipes-for-AutoPkg': {'URL': 'https://github.com/facebook/Recipes-for-AutoPkg.git'}},
 'RECIPE_REPO_DIR': '/Users/Shared/AutoPkg/RecipeRepos',
 'RECIPE_SEARCH_DIRS': ['.',
                        '~/Library/AutoPkg/Recipes',
                        '/Library/AutoPkg/Recipes',
                        '/Users/Shared/AutoPkg/Recipes',
                        '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.recipes',
                        '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.justinrummel-recipes',
                        '/Users/Shared/AutoPkg/RecipeRepos/com.github.facebook.Recipes-for-AutoPkg',
                        '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.jessepeterson-recipes',
                        '/Users/Shared/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes'],
 'download_changed': True,
 'etag': '"d4d8324c65b7fe87e5605763a8189b80:1573582460.573331"',
 'filename': 'com.vmware.fusion.zip.tar',
 'last_modified': 'Tue, 05 Nov 2019 05:58:32 GMT',
 'pathname': '/Users/Shared/AutoPkg/Cache/com.justinrummel.download.VMwareFusion/downloads/com.vmware.fusion.zip.tar',
 'prefetch_filename': False,
 'product_name': 'fusion.xml',
 'url': 'https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/11.5.1/15018442/core/com.vmware.fusion.zip.tar',
 'url_downloader_summary_result': {'data': {'download_path': '/Users/Shared/AutoPkg/Cache/com.justinrummel.download.VMwareFusion/downloads/com.vmware.fusion.zip.tar'},
                                   'summary_text': 'The following new items '
                                                   'were downloaded:'},
 'verbose': 4,
 'version': '11.5.1'}
Receipt written to /Users/Shared/AutoPkg/Cache/com.justinrummel.download.VMwareFusion/receipts/VMwareFusion-receipt-20191203-124721.plist

The following new items were downloaded:
    Download Path
    -------------
    /Users/Shared/AutoPkg/Cache/com.justinrummel.download.VMwareFusion/downloads/com.vmware.fusion.zip.tar
```