### PR TITLE
Bump major version to 12

### DIFF
--- a/VMware Fusion/VMwareFusionURLProvider.py
+++ b/VMware Fusion/VMwareFusionURLProvider.py
@@ -38,7 +38,7 @@ __all__ = ["VMwareFusionURLProvider"]
 # variables
 VMWARE_BASE_URL = "https://softwareupdate.vmware.com/cds/vmw-desktop/"
 FUSION = "fusion.xml"
-DEFAULT_MAJOR_VERSION = "11"
+DEFAULT_MAJOR_VERSION = "12"
 
 
 class VMwareFusionURLProvider(URLGetter):


### PR DESCRIPTION
I don't know if this is the right way to approach this, but changing `DEFAULT_MAJOR_VERSION` results in the recipe downloading Fusion 12 instead of Fusion 11.