### PR TITLE
Adjust PkgCreator arguments

### DIFF
--- a/VMware Fusion/VMwareFusion.pkg.recipe
+++ b/VMware Fusion/VMwareFusion.pkg.recipe
@@ -90,10 +90,10 @@
 			<string>PkgCreator</string>
 			<key>Arguments</key>
 			<dict>
-				<key>pkgname</key>
-				<string>%NAME%-%version%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%-%version%</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>


### PR DESCRIPTION
`pkgname` is [intended](https://github.com/autopkg/autopkg/blob/e36d5cba2823dbdfcb69a41a38b1aef9fb76121c/Code/autopkgserver/autopkgserver#L47) to be in the `pkg_request` dictionary, not as a standalone argument for [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator).