### PR TITLE
Add missing Munki repo subdirectory variable

### DIFF
--- a/VMware Fusion/VMwareFusion.pkg.munki.recipe
+++ b/VMware Fusion/VMwareFusion.pkg.munki.recipe
@@ -52,7 +52,10 @@
 			<key>Processor</key>
 			<string>MunkiImporter</string>
 			<key>Arguments</key>
-			<dict/>
+			<dict>
+				<key>repo_subdirectory</key>
+				<string>%MUNKI_REPO_SUBDIR%</string>
+			</dict>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
`MUNKI_REPO_SUBDIR` was included as an input variable, but not referenced by MunkiImporter.

