### PR TITLE
fix path to Install TeamViewer.pkg

### DIFF
--- a/TeamViewer/TeamViewer.pkg.recipe
+++ b/TeamViewer/TeamViewer.pkg.recipe
@@ -1,82 +1,82 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-    <key>Description</key>
-    <string>Uses io.github.hjuutilainen.download.TeamViewer recipe to download latest TeamViewer</string>
-    <key>Identifier</key>
-    <string>com.justinrummel.pkg.TeamViewer</string>
-    <key>Input</key>
     <dict>
-        <key>NAME</key>
-        <string>TeamViewer</string>
-    </dict>
-    <key>MinimumVersion</key>
-    <string>0.2.5</string>
-    <key>ParentRecipe</key>
-    <string>io.github.hjuutilainen.download.TeamViewer</string>
-    <key>Process</key>
-    <array>
+        <key>Description</key>
+        <string>Uses io.github.hjuutilainen.download.TeamViewer recipe to download latest TeamViewer</string>
+        <key>Identifier</key>
+        <string>com.justinrummel.pkg.TeamViewer</string>
+        <key>Input</key>
         <dict>
-            <key>Processor</key>
-            <string>FlatPkgUnpacker</string>
-            <key>Arguments</key>
-            <dict>
-                <key>flat_pkg_path</key>
-                <string>%pathname%/*.pkg</string>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/unpack</string>
-            </dict>
+            <key>NAME</key>
+            <string>TeamViewer</string>
         </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PkgRootCreator</string>
-            <key>Arguments</key>
+        <key>MinimumVersion</key>
+        <string>0.2.5</string>
+        <key>ParentRecipe</key>
+        <string>io.github.hjuutilainen.download.TeamViewer</string>
+        <key>Process</key>
+        <array>
             <dict>
-                <key>pkgroot</key>
-                <string>%RECIPE_CACHE_DIR%/payload/root/Applications</string>
-                <key>pkgdirs</key>
-                 <dict/>
+                <key>Processor</key>
+                <string>FlatPkgUnpacker</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>flat_pkg_path</key>
+                    <string>%pathname%/Install TeamViewer.app/Contents/Resources/Install TeamViewer.pkg</string>
+                    <key>destination_path</key>
+                    <string>%RECIPE_CACHE_DIR%/unpack</string>
+                </dict>
             </dict>
-        </dict>
-        <dict>
-            <key>Comment</key>
-            <string>TeamViewer 9 installs in /Applications/TeamViewer.app so extract accordingly</string>
-            <key>Processor</key>
-            <string>PkgPayloadUnpacker</string>
-            <key>Arguments</key>
             <dict>
-                <key>pkg_payload_path</key>
-                <string>%RECIPE_CACHE_DIR%/unpack/TeamViewerApp.pkg/Payload</string>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/payload/root/Applications</string>
+                <key>Processor</key>
+                <string>PkgRootCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>pkgroot</key>
+                    <string>%RECIPE_CACHE_DIR%/payload/root/Applications</string>
+                    <key>pkgdirs</key>
+                    <dict/>
+                </dict>
             </dict>
-        </dict>
-        <dict>
-            <key>Comment</key>
-            <string>Get version from the app</string>
-            <key>Processor</key>
-            <string>Versioner</string>
-            <key>Arguments</key>
             <dict>
-                <key>input_plist_path</key>
-                <string>%pkgroot%/TeamViewer.app/Contents/Info.plist</string>
-                <key>plist_version_key</key>
-                <string>CFBundleShortVersionString</string>
+                <key>Comment</key>
+                <string>TeamViewer 9 installs in /Applications/TeamViewer.app so extract accordingly</string>
+                <key>Processor</key>
+                <string>PkgPayloadUnpacker</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>pkg_payload_path</key>
+                    <string>%RECIPE_CACHE_DIR%/unpack/TeamViewerApp.pkg/Payload</string>
+                    <key>destination_path</key>
+                    <string>%RECIPE_CACHE_DIR%/payload/root/Applications</string>
+                </dict>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PkgCopier</string>
-            <key>Arguments</key>
             <dict>
-                <key>source_pkg</key>
-                <string>%pathname%/Install TeamViewer.pkg</string>
-                <key>pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/TeamViewer-%version%.pkg</string>
+                <key>Comment</key>
+                <string>Get version from the app</string>
+                <key>Processor</key>
+                <string>Versioner</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>input_plist_path</key>
+                    <string>%pkgroot%/TeamViewer.app/Contents/Info.plist</string>
+                    <key>plist_version_key</key>
+                    <string>CFBundleShortVersionString</string>
+                </dict>
             </dict>
-        </dict>
+            <dict>
+                <key>Processor</key>
+                <string>PkgCopier</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>source_pkg</key>
+                    <string>%flat_pkg_path%</string>
+                    <key>pkg_path</key>
+                    <string>%RECIPE_CACHE_DIR%/TeamViewer-%version%.pkg</string>
+                </dict>
+            </dict>
 
-    </array>
-</dict>
+        </array>
+    </dict>
 </plist>


### PR DESCRIPTION
Hi @justinrummel, this PR fixes the broken TeamViewer.pkg recipe. `Install TeamViewer.pkg` was moved inside an `Install TeamViewer.app` so the `flat_pkg_path` needed to be changed.

The other changes are just some prettifying of the XML.