### PR TITLE
VMware Fusion 13.x and later have a new URL to check.

### DIFF
--- a/VMware Fusion/VMwareFusion.download.recipe
+++ b/VMware Fusion/VMwareFusion.download.recipe
@@ -21,7 +21,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>product_name</key>
-				<string>fusion.xml</string>
+				<string>fusion-universal.xml</string>
 			</dict>
 		</dict>
 		<dict>

--- a/VMware Fusion/VMwareFusionURLProvider.py
+++ b/VMware Fusion/VMwareFusionURLProvider.py
@@ -37,7 +37,7 @@ __all__ = ["VMwareFusionURLProvider"]
 
 # variables
 VMWARE_BASE_URL = "https://softwareupdate.vmware.com/cds/vmw-desktop/"
-FUSION = "fusion.xml"
+FUSION = "fusion-universal.xml"
 DEFAULT_MAJOR_VERSION = "13"
 
 


### PR DESCRIPTION
All releases of VMware Fusion 13.0 and onward use `fusion-universal.xml` for the filename to check, in place of the former `fusion.xml`.

Was: https://softwareupdate.vmware.com/cds/vmw-desktop/fusion.xml
Now: https://softwareupdate.vmware.com/cds/vmw-desktop/fusion-universal.xml