### PR TITLE
Fix Wireshark dev recipes and add ARCH input variable

### DIFF
--- a/WiresharkDev/WiresharkDev.download.recipe
+++ b/WiresharkDev/WiresharkDev.download.recipe
@@ -3,13 +3,20 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>the Development release of Wireshark.</string>
+    <string>Downloads the latest automated development build of Wireshark. (For stable versions of Wireshark, see the Wireshark recipes in homebysix-recipes.)
+    
+Valid values for ARCH include:
+- "Intel" (default, Intel)
+- "Arm" (Apple Silicon)
+</string>
     <key>Identifier</key>
     <string>com.justinrummel.download.WiresharkDev</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>
         <string>Wireshark</string>
+        <key>ARCH</key>
+        <string>Intel</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.4.0</string>
@@ -21,19 +28,9 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>https://www.wireshark.org/download.html</string>
-                <key>request_headers</key>
-                <dict>
-                    <key>User-Agent</key>
-                    <string>Safari 8.0.2</string>
-                </dict>
+                <string>https://www.wireshark.org/download/automated/osx/?C=M;O=D</string>
                 <key>re_pattern</key>
-                <string>((Wireshark)( |%20)(3)\.(\d{1,2})\.(\d{1,2})(|rc\d{1,2})( |%20)(Intel)( |%20)(64\.dmg))</string>
-                <key>re_flags</key>
-                <array>
-                    <string>MULTILINE</string>
-                    <string>DOTALL</string>
-                </array>
+                <string>href="(Wireshark%20[\d\.]+rc[0-9a-z\-]+%20%ARCH%%2064\.dmg)"</string>
                 <key>result_output_var_name</key>
                 <string>match</string>
             </dict>
@@ -44,14 +41,25 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>https://1.na.dl.wireshark.org/osx/%match%</string>
+                <string>https://www.wireshark.org/download/automated/osx/%match%</string>
                 <key>filename</key>
-                <string>%match%</string>
+                <string>%NAME%.dmg</string>
             </dict>
         </dict>
         <dict>
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%/Wireshark.app</string>
+                <key>requirement</key>
+                <string>identifier "org.wireshark.Wireshark" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7Z6EMTD2C6"</string>
+            </dict>
         </dict>
     </array>
 </dict>

--- a/WiresharkDev/WiresharkDev.pkg.recipe
+++ b/WiresharkDev/WiresharkDev.pkg.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>PKG Wireshark Dev from download recipe</string>
+    <string>Downloads the latest automated development build of Wireshark and creates a pkg. (For stable versions of Wireshark, see the Wireshark recipes in homebysix-recipes.)</string>
 	<key>Identifier</key>
 	<string>com.justinrummel.pkg.WiresharkDev</string>
 	<key>Input</key>
@@ -19,60 +19,8 @@
 	<array>
 		<dict>
             <key>Processor</key>
-            <string>FlatPkgUnpacker</string>
-            <key>Arguments</key>
-            <dict>
-                <key>flat_pkg_path</key>
-                <string>%pathname%/*.pkg</string>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/unpack</string>
-            </dict>
+            <string>AppPkgCreator</string>
         </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PkgPayloadUnpacker</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pkg_payload_path</key>
-                <string>%RECIPE_CACHE_DIR%/unpack/wireshark.pkg/Payload</string>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/payload</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>Versioner</string>
-            <key>Arguments</key>
-            <dict>
-                <key>input_plist_path</key>
-                <string>%RECIPE_CACHE_DIR%/payload/Wireshark.app/Contents/Info.plist</string>
-                <key>plist_version_key</key>
-                <string>CFBundleShortVersionString</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PkgCopier</string>
-            <key>Arguments</key>
-            <dict>
-				<key>source_pkg</key>
-                <string>%pathname%/*.pkg</string>
-                <key>pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
-            </dict>
-        </dict>
-        <dict>
-			<key>Processor</key>
-			<string>PathDeleter</string>
-			<key>Arguments</key>
-			<dict>
-				<key>path_list</key>
-				<array>
-					<string>%RECIPE_CACHE_DIR%/unpack</string>
-					<string>%RECIPE_CACHE_DIR%/payload</string>
-				</array>
-			</dict>
-		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
This PR updates the WiresharkDev recipes to download from the automated dev builds, and adds an ARCH input variable that lets us specify whether to obtain the Intel or Apple Silicon build.

Verbose download/pkg recipe run output with default (Intel) architecture:

```
% autopkg run -vvq WiresharkDev.{download,pkg}.recipe
Processing WiresharkDev.download.recipe...
WARNING: WiresharkDev.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href="(Wireshark%20[\\d\\.]+rc[0-9a-z\\-]+%20Intel%2064\\.dmg)"',
           'result_output_var_name': 'match',
           'url': 'https://www.wireshark.org/download/automated/osx/?C=M;O=D'}}
URLTextSearcher: Found matching text (match): Wireshark%204.5.0rc0-1386-gea8ecf001b07%20Intel%2064.dmg
{'Output': {'match': 'Wireshark%204.5.0rc0-1386-gea8ecf001b07%20Intel%2064.dmg'}}
URLDownloader
{'Input': {'filename': 'Wireshark.dmg',
           'url': 'https://www.wireshark.org/download/automated/osx/Wireshark%204.5.0rc0-1386-gea8ecf001b07%20Intel%2064.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Sun, 29 Dec 2024 01:45:06 GMT
URLDownloader: Storing new ETag header: "42cbeba-62a5ed86b357a"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.justinrummel.download.WiresharkDev/downloads/Wireshark.dmg
{'Output': {'download_changed': True,
            'etag': '"42cbeba-62a5ed86b357a"',
            'last_modified': 'Sun, 29 Dec 2024 01:45:06 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.justinrummel.download.WiresharkDev/downloads/Wireshark.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.justinrummel.download.WiresharkDev/downloads/Wireshark.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.justinrummel.download.WiresharkDev/downloads/Wireshark.dmg/Wireshark.app',
           'requirement': 'identifier "org.wireshark.Wireshark" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"7Z6EMTD2C6"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.justinrummel.download.WiresharkDev/downloads/Wireshark.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.v6fSyl/Wireshark.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.v6fSyl/Wireshark.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.v6fSyl/Wireshark.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.justinrummel.download.WiresharkDev/receipts/WiresharkDev.download-receipt-20241228-201611.plist
Processing WiresharkDev.pkg.recipe...
WARNING: WiresharkDev.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href="(Wireshark%20[\\d\\.]+rc[0-9a-z\\-]+%20Intel%2064\\.dmg)"',
           'result_output_var_name': 'match',
           'url': 'https://www.wireshark.org/download/automated/osx/?C=M;O=D'}}
URLTextSearcher: Found matching text (match): Wireshark%204.5.0rc0-1386-gea8ecf001b07%20Intel%2064.dmg
{'Output': {'match': 'Wireshark%204.5.0rc0-1386-gea8ecf001b07%20Intel%2064.dmg'}}
URLDownloader
{'Input': {'filename': 'Wireshark.dmg',
           'url': 'https://www.wireshark.org/download/automated/osx/Wireshark%204.5.0rc0-1386-gea8ecf001b07%20Intel%2064.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Sun, 29 Dec 2024 01:45:06 GMT
URLDownloader: Storing new ETag header: "42cbeba-62a5ed86b357a"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.justinrummel.pkg.WiresharkDev/downloads/Wireshark.dmg
{'Output': {'download_changed': True,
            'etag': '"42cbeba-62a5ed86b357a"',
            'last_modified': 'Sun, 29 Dec 2024 01:45:06 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.justinrummel.pkg.WiresharkDev/downloads/Wireshark.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.justinrummel.pkg.WiresharkDev/downloads/Wireshark.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.justinrummel.pkg.WiresharkDev/downloads/Wireshark.dmg/Wireshark.app',
           'requirement': 'identifier "org.wireshark.Wireshark" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"7Z6EMTD2C6"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.justinrummel.pkg.WiresharkDev/downloads/Wireshark.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.blospw/Wireshark.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.blospw/Wireshark.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.blospw/Wireshark.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.justinrummel.pkg.WiresharkDev/downloads/Wireshark.dmg
AppPkgCreator: Using path '/private/tmp/dmg.ycf0q6/Wireshark.app' matched from globbed '/private/tmp/dmg.ycf0q6/*.app'.
AppPkgCreator: Version: 4.5.0rc0-1386-gea8ecf001b07
AppPkgCreator: BundleID: org.wireshark.Wireshark
AppPkgCreator: Copied /private/tmp/dmg.ycf0q6/Wireshark.app to ~/Library/AutoPkg/Cache/com.justinrummel.pkg.WiresharkDev/payload/Applications/Wireshark.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'org.wireshark.Wireshark',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.justinrummel.pkg.WiresharkDev/Wireshark-4.5.0rc0-1386-gea8ecf001b07.pkg',
                                                        'version': '4.5.0rc0-1386-gea8ecf001b07'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '4.5.0rc0-1386-gea8ecf001b07'}}
Receipt written to ~/Library/AutoPkg/Cache/com.justinrummel.pkg.WiresharkDev/receipts/WiresharkDev.pkg-receipt-20241228-201625.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.justinrummel.download.WiresharkDev/downloads/Wireshark.dmg
    ~/Library/AutoPkg/Cache/com.justinrummel.pkg.WiresharkDev/downloads/Wireshark.dmg

The following packages were built:
    Identifier               Version                      Pkg Path
    ----------               -------                      --------
    org.wireshark.Wireshark  4.5.0rc0-1386-gea8ecf001b07  ~/Library/AutoPkg/Cache/com.justinrummel.pkg.WiresharkDev/Wireshark-4.5.0rc0-1386-gea8ecf001b07.pkg
```

Verbose download/pkg recipe run output with Apple Silicon architecture:

```
% autopkg run -vvq WiresharkDev.{download,pkg}.recipe -k ARCH=Arm
Processing WiresharkDev.download.recipe...
WARNING: WiresharkDev.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href="(Wireshark%20[\\d\\.]+rc[0-9a-z\\-]+%20Arm%2064\\.dmg)"',
           'result_output_var_name': 'match',
           'url': 'https://www.wireshark.org/download/automated/osx/?C=M;O=D'}}
URLTextSearcher: Found matching text (match): Wireshark%204.5.0rc0-1386-gea8ecf001b07%20Arm%2064.dmg
{'Output': {'match': 'Wireshark%204.5.0rc0-1386-gea8ecf001b07%20Arm%2064.dmg'}}
URLDownloader
{'Input': {'filename': 'Wireshark.dmg',
           'url': 'https://www.wireshark.org/download/automated/osx/Wireshark%204.5.0rc0-1386-gea8ecf001b07%20Arm%2064.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Sun, 29 Dec 2024 01:25:05 GMT
URLDownloader: Storing new ETag header: "401595e-62a5e90d206e9"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.justinrummel.download.WiresharkDev/downloads/Wireshark.dmg
{'Output': {'download_changed': True,
            'etag': '"401595e-62a5e90d206e9"',
            'last_modified': 'Sun, 29 Dec 2024 01:25:05 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.justinrummel.download.WiresharkDev/downloads/Wireshark.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.justinrummel.download.WiresharkDev/downloads/Wireshark.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.justinrummel.download.WiresharkDev/downloads/Wireshark.dmg/Wireshark.app',
           'requirement': 'identifier "org.wireshark.Wireshark" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"7Z6EMTD2C6"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.justinrummel.download.WiresharkDev/downloads/Wireshark.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.UmbQ3r/Wireshark.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.UmbQ3r/Wireshark.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.UmbQ3r/Wireshark.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.justinrummel.download.WiresharkDev/receipts/WiresharkDev.download-receipt-20241228-201719.plist
Processing WiresharkDev.pkg.recipe...
WARNING: WiresharkDev.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href="(Wireshark%20[\\d\\.]+rc[0-9a-z\\-]+%20Arm%2064\\.dmg)"',
           'result_output_var_name': 'match',
           'url': 'https://www.wireshark.org/download/automated/osx/?C=M;O=D'}}
URLTextSearcher: Found matching text (match): Wireshark%204.5.0rc0-1386-gea8ecf001b07%20Arm%2064.dmg
{'Output': {'match': 'Wireshark%204.5.0rc0-1386-gea8ecf001b07%20Arm%2064.dmg'}}
URLDownloader
{'Input': {'filename': 'Wireshark.dmg',
           'url': 'https://www.wireshark.org/download/automated/osx/Wireshark%204.5.0rc0-1386-gea8ecf001b07%20Arm%2064.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Sun, 29 Dec 2024 01:25:05 GMT
URLDownloader: Storing new ETag header: "401595e-62a5e90d206e9"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.justinrummel.pkg.WiresharkDev/downloads/Wireshark.dmg
{'Output': {'download_changed': True,
            'etag': '"401595e-62a5e90d206e9"',
            'last_modified': 'Sun, 29 Dec 2024 01:25:05 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.justinrummel.pkg.WiresharkDev/downloads/Wireshark.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.justinrummel.pkg.WiresharkDev/downloads/Wireshark.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.justinrummel.pkg.WiresharkDev/downloads/Wireshark.dmg/Wireshark.app',
           'requirement': 'identifier "org.wireshark.Wireshark" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"7Z6EMTD2C6"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.justinrummel.pkg.WiresharkDev/downloads/Wireshark.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.3o4h6S/Wireshark.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.3o4h6S/Wireshark.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.3o4h6S/Wireshark.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.justinrummel.pkg.WiresharkDev/downloads/Wireshark.dmg
AppPkgCreator: Using path '/private/tmp/dmg.rJtCma/Wireshark.app' matched from globbed '/private/tmp/dmg.rJtCma/*.app'.
AppPkgCreator: Version: 4.5.0rc0-1386-gea8ecf001b07
AppPkgCreator: BundleID: org.wireshark.Wireshark
AppPkgCreator: Copied /private/tmp/dmg.rJtCma/Wireshark.app to ~/Library/AutoPkg/Cache/com.justinrummel.pkg.WiresharkDev/payload/Applications/Wireshark.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'org.wireshark.Wireshark',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.justinrummel.pkg.WiresharkDev/Wireshark-4.5.0rc0-1386-gea8ecf001b07.pkg',
                                                        'version': '4.5.0rc0-1386-gea8ecf001b07'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '4.5.0rc0-1386-gea8ecf001b07'}}
Receipt written to ~/Library/AutoPkg/Cache/com.justinrummel.pkg.WiresharkDev/receipts/WiresharkDev.pkg-receipt-20241228-201734.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.justinrummel.download.WiresharkDev/downloads/Wireshark.dmg
    ~/Library/AutoPkg/Cache/com.justinrummel.pkg.WiresharkDev/downloads/Wireshark.dmg

The following packages were built:
    Identifier               Version                      Pkg Path
    ----------               -------                      --------
    org.wireshark.Wireshark  4.5.0rc0-1386-gea8ecf001b07  ~/Library/AutoPkg/Cache/com.justinrummel.pkg.WiresharkDev/Wireshark-4.5.0rc0-1386-gea8ecf001b07.pkg
```

