### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/AgileBits/1Password.pkg.recipe
+++ b/AgileBits/1Password.pkg.recipe
@@ -72,8 +72,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>ws.agile.1Password</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Bjango/iStatMenus.pkg.recipe
+++ b/Bjango/iStatMenus.pkg.recipe
@@ -70,8 +70,6 @@
 					<string>%version%</string>
 					<key>id</key>
 					<string>ws.agile.1Password</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/SublimeText/SublimeText3.pkg.recipe
+++ b/SublimeText/SublimeText3.pkg.recipe
@@ -65,8 +65,6 @@
 					<string>%version%</string>
 					<key>id</key>
 					<string>com.sublimetext.3</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/TeamViewer/TeamViewerQS.pkg.recipe
+++ b/TeamViewer/TeamViewerQS.pkg.recipe
@@ -77,8 +77,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>com.teamviewer.TeamViewerQS</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/VMware Fusion/VMwareFusion.pkg.recipe
+++ b/VMware Fusion/VMwareFusion.pkg.recipe
@@ -98,8 +98,6 @@
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>
 					<string>com.vmware.fusion</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and removes the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._